### PR TITLE
Correct mobile class on account delete tab heading

### DIFF
--- a/core/um-actions-account.php
+++ b/core/um-actions-account.php
@@ -213,7 +213,7 @@
 
 		if ( $output ) { ?>
 
-		<div class="um-account-heading uimob300-hide uimob500-hide"><i class="<?php echo $icon; ?>"></i><?php echo $title; ?></div>
+		<div class="um-account-heading uimob340-hide uimob500-hide"><i class="<?php echo $icon; ?>"></i><?php echo $title; ?></div>
 
 		<?php echo wpautop( um_get_option('delete_account_text') ); ?>
 


### PR DESCRIPTION
.uimob300-hide (instead of .uimob340-hide) applied to element meant the "display:none" styling did not get applied on mobile screens.